### PR TITLE
fix(gitignore): ajout de exclusion/.idea/ 🛠️

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.env
-/.idea/
 /vendor/
 /var/
+/.idea/


### PR DESCRIPTION
### Titre :
fix(gitignore): ajout de l'exclusion /.idea/ 🛠️

### Description :
Cette pull request corrige le fichier .gitignore en ajoutant l'exclusion pour le dossier .idea/, généré par les IDE comme PhpStorm.

### Détails des changements :
Ajout de l'exclusion /.idea/ pour éviter d'inclure les fichiers de configuration spécifiques à l'environnement de développement dans le dépôt Git.
Permet de maintenir un dépôt propre et indépendant des configurations IDE des développeurs.
Contexte
Le dossier .idea/ contient des fichiers locaux non nécessaires au projet partagé, tels que les configurations d'environnement spécifiques à chaque développeur.

### Checklist :

- [X]  Mise à jour du fichier .gitignore.
- [X]  Testé pour s'assurer qu'aucun fichier .idea/ n'est désormais suivi par Git.
